### PR TITLE
fix: weekly-blog.yml の on: セクションの構文エラーを修正

### DIFF
--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # 毎週月曜 9:00 UTC（日本時間18:00）
   workflow_dispatch:      # 手動実行も可能
-    # Every Monday at 09:00 UTC
-    - cron: "0 9 * * 1"
-  workflow_dispatch:
     inputs:
       blog_mode:
         description: "LLM backend: openai or ollama"


### PR DESCRIPTION
workflow_dispatch が重複定義されており、かつ無効な cron エントリが含まれていた。 重複を削除し、schedule と workflow_dispatch を正しく分離した。

https://claude.ai/code/session_01HNWnPf8zBynNXWqkcdBNFh