### PR TITLE
Differentiate English blog as analytical research-note style

### DIFF
--- a/scripts/generate_weekly_blog.py
+++ b/scripts/generate_weekly_blog.py
@@ -645,37 +645,34 @@ def build_prompt(
             "   ログの実際のテーマを反映した見出しを選ぶこと。"
         )
 
+        task_instruction = (
+            "Write an engaging blog post in Markdown based on the decision logs below.\n"
+            "The post should feel like a genuine personal reflection — not a dry summary."
+        )
+
     else:
         role_text = (
-            "You are a writer with the following persona:\n"
-            "An observer and experimenter with quiet but sustained passion.\n"
-            "A humble inquirer who presents ideas as hypotheses, not assertions.\n"
-            "A creator who always connects insights back to their own practice.\n"
-            "A thinker who decomposes and reconnects concepts.\n"
-            'Someone who views the world through the lens of "mechanisms" and "systems".\n'
+            "You are a technical writer documenting weekly research and experimentation.\n"
+            "Your style is precise, informative, and analytical — closer to a research note or technical essay than a personal blog.\n"
+            "You favor clarity and insight over warmth and personal expression.\n"
+            "You focus on patterns, design decisions, and implications rather than emotions or reactions.\n"
             f"Today is {date_str}."
         )
 
         language_guidance = (
             "- Write in first person, in English (the logs may be in Japanese; translate and interpret)\n"
-            "- Hedging ratio: Use assertive and hedged expressions at roughly 6:4 to 5:5."
-            ' Prefer: "I think…", "It seems that…", "One might argue…", "Perhaps…", "I wonder whether…"\n'
-            "- Opening: Begin with one of — (a) a concrete fact or observation, (b) a situational setup, (c) a brief backstory\n"
-            '- Headings: Use "Concept: Angle" format for all H2 headings. Avoid chronological labels (Step 1 / Next / Finally)\n'
-            "- Paragraphs: 1–3 sentences per paragraph. Break long blocks with line breaks\n"
-            "- Vocabulary injection is optional. If used, keep it to 3–6 instances.\n"
-            "- Abstract words such as mechanism, apparatus, texture, granularity, and hypothesis should be used only when they clarify a concrete source detail.\n"
-            "- Do not repeat the same abstract motif across multiple sections.\n"
-            "- Prefer concrete project names, tools, design decisions, comparison points, and source-specific details over abstract phrasing.\n"
-            '- Connectors: Scatter: "That said,", "In other words,", "On the other hand,", "If so,", "One might wonder whether", "Conversely,"\n'
-            "- Thinking patterns: Leave traces of (a) decomposing abstraction into 2–3 elements,"
-            " (b) micro↔macro oscillation, (c) contrast pairs (digital/physical, local/global, explicit/implicit)\n"
-            "- Closing: End with connection to own practice, universalization of the theme, a quiet closing remark, or publication date\n"
-            '- Forbidden words: Avoid "amazing", "awesome", "literally", "totally", "absolutely", "definitely",'
-            ' "it\'s insane that", slang intensifiers, and emojis in body text\n'
-            '- Self-reference: Include 1–2 explicit "I think / I believe / I suspect" phrases at section transitions\n'
-            "- Be specific: mention project names, tools, and concrete outcomes\n"
-            "- Total length: around 2000–3000 characters"
+            "- Maintain analytical distance; avoid emotional or subjective reactions\n"
+            "- Prefer clear, declarative sentences over hedged or speculative phrasing\n"
+            "- Opening (1–2 sentences): state the week's central finding, question, or area of investigation\n"
+            "- Headings: describe what was investigated, built, or decided — prefer concrete subjects over abstract concepts\n"
+            "- Paragraphs: 2–4 sentences; informative and precise\n"
+            "- No vocabulary injection; use technical terms from the source logs directly\n"
+            '- Connectors: prefer "This suggests", "The implication is", "A key finding was", "In contrast", "As a result"\n'
+            "- Closing: synthesize the week's findings or implications — what the work points toward technically or conceptually\n"
+            "- Forbidden: emotional adjectives, slang intensifiers, emojis, first-person feelings"
+            ' (e.g., "I felt", "I was excited", "I enjoyed")\n'
+            "- Be specific: mention project names, tools, design decisions, and concrete outcomes\n"
+            "- Total length: around 1500–2500 characters"
         )
 
         coverage_requirements = (
@@ -693,7 +690,7 @@ def build_prompt(
             "Constraints (strictly follow):\n"
             "- Do not introduce topics, proper nouns, episodes, or people not present in the source logs\n"
             "- Do not alter the stance or position of arguments in the logs\n"
-            "- Do not over-inject vocabulary (3–6 instances maximum, optional)\n"
+            "- Do not use abstract vocabulary for its own sake; use technical terms from the source logs\n"
             "- Do not fabricate emotions or reactions\n"
             "- Do not increase or decrease the critical intensity toward others' work\n"
             "- Do not introduce new themes not analysed in the source\n"
@@ -702,12 +699,11 @@ def build_prompt(
 
         final_gate = (
             "Before writing your output, confirm each of the following:\n"
-            '- [ ] Topics, claims, and proper nouns match the source logs\n'
-            '- [ ] The post reads as written by someone who "observes, decomposes, and connects to practice"\n'
-            "- [ ] Assertions and hedged expressions are appropriately mixed\n"
-            "- [ ] At least one concrete↔abstract connection is present\n"
-            "- [ ] The closing connects to own practice or universalises the theme\n"
-            "- [ ] Vocabulary injection feels natural and is not excessive\n"
+            "- [ ] Topics, claims, and proper nouns match the source logs\n"
+            "- [ ] The tone is analytical and informative, not personal or emotional\n"
+            "- [ ] Personal feelings and reactions are absent from the text\n"
+            "- [ ] The closing synthesizes findings or implications without personal reflection\n"
+            "- [ ] Technical terms are used precisely, from the source logs\n"
             "- [ ] Multiple Source Cards are concretely reflected in the body\n"
             "- [ ] The article is not dominated by a single source\n"
             "- [ ] The post shows what was investigated, built, compared, or decided, not only an abstract theme"
@@ -715,18 +711,22 @@ def build_prompt(
 
         required_structure = (
             "Required structure:\n"
-            "1. `# <Title>` — a short, catchy, article-style title in 30 characters or fewer"
-            " that makes the reader feel curious, excited, or emotionally engaged; do not use a generic date-based title\n"
-            "2. An opening paragraph (2–3 sentences) using one of: fact presentation / situational setup / backstory\n"
-            "3. Free-form body sections using H2 headings in \"Concept: Angle\" format.\n"
-            "   Do NOT use fixed section names (Highlights / What I Worked On / etc.).\n"
-            "   Choose headings that reflect the actual themes in the logs."
+            "1. `# <Title>` — concise, descriptive title stating the subject matter; 50 characters or fewer\n"
+            "2. Opening (1–2 sentences): state the week's central finding, question, or area of investigation\n"
+            "3. Body sections using H2 headings that describe what was investigated, built, or decided.\n"
+            "   Do NOT use fixed section names (Highlights / Summary / etc.).\n"
+            '   Do NOT use vague abstract headings — prefer concrete subjects'
+            ' (e.g., "DB Schema: Event Sourcing Approach", "Agent Aiko: Persistent Persona Design").'
+        )
+
+        task_instruction = (
+            "Write a research note in Markdown based on the decision logs below.\n"
+            "The post should read as a technical research document — analytical, precise, and informative."
         )
 
     return f"""{role_text}
 
-Write an engaging blog post in Markdown based on the decision logs below.
-The post should feel like a genuine personal reflection — not a dry summary.
+{task_instruction}
 
 {required_structure}
 

--- a/scripts/tests/test_generate_weekly_blog.py
+++ b/scripts/tests/test_generate_weekly_blog.py
@@ -197,9 +197,11 @@ class TestBuildPrompt:
         assert "Previous blog post" not in prompt
 
     def test_includes_prompt_guidance_strings(self):
-        prompt = gen.build_prompt("logs", "cards", "capsule", date(2026, 3, 10), "en")
-        assert "Concept: Angle" in prompt
-        assert "Before writing your output, confirm each of the following" in prompt
+        # English uses research-note style; Japanese uses "Concept: Angle" essay format
+        prompt_ja = gen.build_prompt("logs", "cards", "capsule", date(2026, 3, 10), "ja")
+        assert "概念：切り口" in prompt_ja
+        prompt_en = gen.build_prompt("logs", "cards", "capsule", date(2026, 3, 10), "en")
+        assert "Before writing your output, confirm each of the following" in prompt_en
 
     def test_japanese_prompt_requests_japanese_output(self):
         prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "ja")
@@ -258,12 +260,30 @@ class TestBuildPrompt:
         assert "複数の Source Card が本文に具体的に反映されている" in prompt
         assert "1つの Source だけに記事が偏っていない" in prompt
 
-    def test_vocabulary_injection_relaxed_en(self):
+    def test_vocabulary_injection_removed_en(self):
         prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "en")
-        assert "optional" in prompt
-        assert "3–6" in prompt
-        # Old forced injection count should not appear
+        # Old forced/optional injection guidance gone
+        assert "Vocabulary injection is optional" not in prompt
         assert "5–15" not in prompt
+        assert "3–6 instances" not in prompt
+
+    def test_en_prompt_analytical_style(self):
+        prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "en")
+        assert "analytical" in prompt
+
+    def test_en_prompt_no_emotional_persona(self):
+        prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "en")
+        assert "quiet but sustained passion" not in prompt
+        assert "humble inquirer" not in prompt
+
+    def test_en_prompt_research_note_task(self):
+        prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "en")
+        assert "research note" in prompt
+
+    def test_en_prompt_final_gate_checks_tone(self):
+        prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "en")
+        assert "analytical and informative" in prompt
+        assert "Personal feelings and reactions are absent" in prompt
 
     def test_vocabulary_injection_relaxed_ja(self):
         prompt = gen.build_prompt("logs", "", "", date(2026, 3, 10), "ja")


### PR DESCRIPTION
## Summary

- English blog style redesigned as an analytical research note, distinct from the Japanese personal-reflection style
- The blog site's auto-translation makes a direct ja→en translation redundant; this gives the English post a genuinely different angle
- Only the English branch of `build_prompt()` is changed — pipeline, source cards, style capsule, and Japanese prompt are untouched

## Changes

| Element | Before | After |
|---|---|---|
| Persona | "quiet passion, humble inquirer, connects to practice" | "technical writer, analytical, precise, research note style" |
| Opening instruction | personal reflection, not a dry summary | research note, analytical, precise, informative |
| Style guidance | hedging ratio 6:4, "I think/believe" self-reference, warm closing | declarative sentences, analytical distance, no emotional language |
| Vocabulary injection | optional 3–6 instances | removed entirely; use source log terms directly |
| Connectors | "I wonder whether", "One might argue" | "This suggests", "The implication is", "A key finding was" |
| Closing | connection to own practice / universalization | synthesis of findings/implications |
| Headings | "Concept: Angle" abstract essay format | concrete subject-based (e.g., "DB Schema: Event Sourcing Approach") |
| Title limit | 30 chars, catchy/emotional | 50 chars, descriptive |
| Length | 2000–3000 chars | 1500–2500 chars |
| Final gate | "observes, decomposes, connects to practice" | "analytical tone, no personal feelings" |

## Test plan

- [x] `pytest scripts/tests/test_generate_weekly_blog.py` — 78 passed, 0 failed
- [x] 4 new tests added for analytical style, no emotional persona, research note framing, tone gate
- [x] 2 existing en prompt tests updated to reflect new behaviour
- [x] Japanese prompt tests all pass unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01JE5xPR19TQbM3sL9aSQnd2)_