### PR TITLE
週次ブログ生成を gx10 ローカル LLM に引き継ぐ（要約=20b/記事=120b/thinking）

### DIFF
--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -1,8 +1,8 @@
 name: Weekly Blog Generator
 
 on:
-  schedule:
-    - cron: '0 9 * * 5'  # 毎週金曜 9:00 UTC
+  # Scheduled generation moved to the gx10 box (local Ollama: gpt-oss 20b/120b).
+  # See scripts/run_weekly_blog_gx10.sh. Cloud run kept only for manual dispatch.
   workflow_dispatch:
     inputs:
       llm_provider:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@
 
 ## GitHub Actions で自動化していること
 ### 1. 週次ブログ生成
-- ワークフロー: `.github/workflows/weekly-blog.yml`
 - 実行スクリプト: `scripts/generate_weekly_blog.py`
 - 内容: `logs/` の直近記録を集約し、日本語版・英語版の週次ブログを `blog/` に出力
 - 詳細: `docs/weekly-blog-generator-spec.md`
+- **定期実行は gx10（ローカル Ollama）に移行**: `scripts/run_weekly_blog_gx10.sh` を gx10 の cron から実行する。要約フェーズは `gpt-oss:20b`、記事生成フェーズは `gpt-oss:120b`、reasoning（thinking）on。土曜 08:00 JST までに完了するよう早朝起動（例: `0 5 * * 6`）。
+  - クラウド（`.github/workflows/weekly-blog.yml`）は `workflow_dispatch` の手動実行のみ残し、定期 cron は停止（二重生成防止）。
+  - モデル切替の環境変数: `OLLAMA_SUMMARIZE_MODEL` / `OLLAMA_COMPOSE_MODEL` / `OLLAMA_THINK` / `OLLAMA_TIMEOUT`
 
 ### 2. 週次ドキュメント目標 Issue 生成
 - ワークフロー: `.github/workflows/weekly-doc-goal-issue.yml`

--- a/scripts/generate_weekly_blog.py
+++ b/scripts/generate_weekly_blog.py
@@ -26,7 +26,11 @@ Environment variables:
     ANTHROPIC_API_KEY required for anthropic mode
     ANTHROPIC_MODEL   model name for anthropic mode (default: claude-sonnet-4-20250514)
     OLLAMA_URL        Ollama endpoint (default: http://localhost:11434)
-    OLLAMA_MODEL      model name for ollama mode (default: llama3)
+    OLLAMA_MODEL      fallback model name for ollama mode (default: gpt-oss:20b)
+    OLLAMA_SUMMARIZE_MODEL  model for the log-summarize phase (default: OLLAMA_MODEL)
+    OLLAMA_COMPOSE_MODEL    model for the article-writing phase (default: gpt-oss:120b)
+    OLLAMA_THINK      enable reasoning/thinking mode (default: true)
+    OLLAMA_TIMEOUT    per-request timeout seconds for ollama (default: 1800)
     BLOG_DATE         override output date (YYYY-MM-DD); default: today UTC
     LOGS_DIR          path to logs directory (default: logs)
     BLOG_DIR          path to blog directory (default: blog)
@@ -59,6 +63,11 @@ ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434").rstrip("/")
 OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gpt-oss:20b")
+# Two-model split: a lightweight model condenses raw logs, a heavyweight model writes the article.
+OLLAMA_SUMMARIZE_MODEL = os.environ.get("OLLAMA_SUMMARIZE_MODEL", OLLAMA_MODEL)
+OLLAMA_COMPOSE_MODEL = os.environ.get("OLLAMA_COMPOSE_MODEL", "gpt-oss:120b")
+OLLAMA_THINK = os.environ.get("OLLAMA_THINK", "true").lower() in ("1", "true", "yes", "on")
+OLLAMA_TIMEOUT = int(os.environ.get("OLLAMA_TIMEOUT", "1800"))
 LOGS_DIR = REPO_ROOT / os.environ.get("LOGS_DIR", "logs")
 BLOG_DIR = REPO_ROOT / os.environ.get("BLOG_DIR", "blog")
 STATE_FILE = REPO_ROOT / os.environ.get("STATE_FILE", ".blog_state.json")
@@ -260,7 +269,7 @@ def summarize_content(content: str, source_name: str) -> str:
     )
     print(f"[generate_weekly_blog] Summarizing: {source_name}")
     try:
-        return generate_blog_content(prompt)
+        return generate_blog_content(prompt, ollama_model=OLLAMA_SUMMARIZE_MODEL)
     except Exception as exc:
         print(
             f"[generate_weekly_blog] Summarization failed for {source_name}: {exc}; "
@@ -810,14 +819,20 @@ def _call_anthropic(prompt: str) -> str:
     return body["content"][0]["text"]
 
 
-def _call_ollama(prompt: str) -> str:
+def _strip_thinking(text: str) -> str:
+    """Remove any inline reasoning block a thinking model may emit in the body."""
+    return re.sub(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", text).strip()
+
+
+def _call_ollama(prompt: str, model: str) -> str:
     import urllib.request
 
     payload = json.dumps(
         {
-            "model": OLLAMA_MODEL,
+            "model": model,
             "prompt": prompt,
             "stream": False,
+            "think": OLLAMA_THINK,
         }
     ).encode()
 
@@ -827,18 +842,24 @@ def _call_ollama(prompt: str) -> str:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=300) as resp:
+    with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT) as resp:
         body = json.loads(resp.read())
-    return body.get("response", "")
+    # With think=true Ollama returns reasoning in a separate "thinking" field, so
+    # "response" already holds the answer; strip any inline block just in case.
+    return _strip_thinking(body.get("response", ""))
 
 
-def generate_blog_content(prompt: str) -> str:
+def generate_blog_content(prompt: str, ollama_model: Optional[str] = None) -> str:
     if LLM_PROVIDER == "anthropic":
         print(f"[generate_weekly_blog] Using Anthropic (model={ANTHROPIC_MODEL})")
         return _call_anthropic(prompt)
     elif LLM_PROVIDER == "ollama":
-        print(f"[generate_weekly_blog] Using Ollama ({OLLAMA_URL}, model={OLLAMA_MODEL})")
-        return _call_ollama(prompt)
+        model = ollama_model or OLLAMA_MODEL
+        print(
+            f"[generate_weekly_blog] Using Ollama ({OLLAMA_URL}, model={model}, "
+            f"think={OLLAMA_THINK})"
+        )
+        return _call_ollama(prompt, model)
     else:
         print(f"[generate_weekly_blog] Using OpenAI (model={OPENAI_MODEL})")
         return _call_openai(prompt)
@@ -933,8 +954,8 @@ def main() -> None:
             debug_dir.mkdir(parents=True, exist_ok=True)
             (debug_dir / f"{post_date}-{language}-prompt.md").write_text(prompt, encoding="utf-8")
 
-        # Generate content
-        content = generate_blog_content(prompt)
+        # Generate content (heavyweight model for the article itself)
+        content = generate_blog_content(prompt, ollama_model=OLLAMA_COMPOSE_MODEL)
 
         # Write output
         output_path = blog_output_path(post_date, language)

--- a/scripts/run_weekly_blog_gx10.sh
+++ b/scripts/run_weekly_blog_gx10.sh
@@ -20,9 +20,16 @@ export OLLAMA_TIMEOUT="${OLLAMA_TIMEOUT:-1800}"
 echo "[run_weekly_blog_gx10] $(date '+%Y-%m-%d %H:%M:%S') start"
 
 git pull -q --ff-only origin main || true
-python3 scripts/generate_weekly_blog.py
 
-if git status --porcelain blog/ .blog_state.json | grep -q .; then
+# Capture output so we can detect an empty-week placeholder and avoid publishing
+# a thin post. The generator prints this line to stderr when no logs are in range.
+RUN_OUT=$(python3 scripts/generate_weekly_blog.py 2>&1)
+echo "$RUN_OUT"
+
+if printf '%s' "$RUN_OUT" | grep -q "No log files found for this period"; then
+    echo "[run_weekly_blog_gx10] no source logs this week — skipping commit (no thin post published)"
+    git checkout -- blog/ .blog_state.json 2>/dev/null || true
+elif git status --porcelain blog/ .blog_state.json | grep -q .; then
     git add blog/ .blog_state.json
     git commit -m "📝 Weekly blog post (gx10 local LLM)"
     git push origin HEAD:main

--- a/scripts/run_weekly_blog_gx10.sh
+++ b/scripts/run_weekly_blog_gx10.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Weekly blog generation on the gx10 box using local Ollama models.
+# Summarize phase -> gpt-oss:20b, article phase -> gpt-oss:120b, reasoning on.
+# Intended to run from cron early Saturday so it finishes before 08:00 JST.
+#
+# Cron (Saturday 05:00 JST, ~3h margin):
+#   0 5 * * 6 /home/masa/dev/logs-with-llm/scripts/run_weekly_blog_gx10.sh >> /tmp/weekly-blog-gx10.log 2>&1
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+export LLM_PROVIDER=ollama
+export OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+export OLLAMA_SUMMARIZE_MODEL="${OLLAMA_SUMMARIZE_MODEL:-gpt-oss:20b}"
+export OLLAMA_COMPOSE_MODEL="${OLLAMA_COMPOSE_MODEL:-gpt-oss:120b}"
+export OLLAMA_THINK="${OLLAMA_THINK:-true}"
+export OLLAMA_TIMEOUT="${OLLAMA_TIMEOUT:-1800}"
+
+echo "[run_weekly_blog_gx10] $(date '+%Y-%m-%d %H:%M:%S') start"
+
+git pull -q --ff-only origin main || true
+python3 scripts/generate_weekly_blog.py
+
+if git status --porcelain blog/ .blog_state.json | grep -q .; then
+    git add blog/ .blog_state.json
+    git commit -m "📝 Weekly blog post (gx10 local LLM)"
+    git push origin HEAD:main
+    echo "[run_weekly_blog_gx10] pushed new blog post"
+else
+    echo "[run_weekly_blog_gx10] no changes to commit"
+fi
+
+echo "[run_weekly_blog_gx10] $(date '+%Y-%m-%d %H:%M:%S') done"


### PR DESCRIPTION
## 概要
週次ブログ生成の定期実行を、クラウド（GitHub Actions / OpenAI）から **gx10 のローカル Ollama** に引き継ぐ。要約と記事生成でモデルを使い分け、reasoning（thinking）を有効化する。Closes #52。

## 変更点
- **2モデル分離**（`scripts/generate_weekly_blog.py`）
  - `OLLAMA_SUMMARIZE_MODEL`（default `gpt-oss:20b`）= ログ要約フェーズ
  - `OLLAMA_COMPOSE_MODEL`（default `gpt-oss:120b`）= 記事本文生成フェーズ
  - `OLLAMA_MODEL` は後方互換フォールバックとして残置
- **thinking on** — `OLLAMA_THINK`(default true)。`_call_ollama` に `model` 引数追加・`"think"` 付与・応答から reasoning ブロックを除去・timeout を `OLLAMA_TIMEOUT`(default 1800s) に延長
- **cron 用ラッパ** `scripts/run_weekly_blog_gx10.sh` — env 設定 → 生成 → `blog/` を commit & push。土曜 08:00 JST までに終わるよう早朝起動想定（例 `0 5 * * 6`、約3hマージン）
- **クラウド定期実行を停止** — `weekly-blog.yml` の `schedule` を外し `workflow_dispatch` のみに（二重生成防止）
- README 更新

## 検証
- 既存テスト `scripts/tests` 88件 green
- gx10 ローカルで `_call_ollama` の thinking 経路をスモークテスト（応答に reasoning が混ざらないことを確認）
- 本番相当のフル生成（120b・thinking）を別途実行して記事品質を確認 → 結果は本PRにコメントで添付予定

## デプロイ（マージ後）
1. gx10 に cron 追加: `0 5 * * 6 /home/masa/dev/logs-with-llm/scripts/run_weekly_blog_gx10.sh >> /tmp/weekly-blog-gx10.log 2>&1`
2. クラウド側 schedule が無効化されていること確認

## 注意
- public リポのため secret は未混入（env はラッパ/cron 側で設定）
